### PR TITLE
Update dependencies to support Laravel 12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,14 +20,14 @@
     ],
     "require": {
         "php": "^8.1",
-        "laravel/framework": "^10.0|^11.0"
+        "laravel/framework": "^10.0|^11.0|^12.0"
     },
     "require-dev": {
-        "larastan/larastan": "^2.9",
+        "larastan/larastan": "^2.9|^3.0",
         "laravel/pint": "^1.17",
-        "orchestra/testbench": "8.*",
-        "pestphp/pest": "^2.34",
-        "pestphp/pest-plugin-laravel": "^2.3"
+        "orchestra/testbench": "8.*|10.*",
+        "pestphp/pest": "^2.34|^3.0",
+        "pestphp/pest-plugin-laravel": "^2.3|^3.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Added compatibility for Laravel 12.0, Larastan 3.0, Pest 3.0, and other related packages. Ensures the project remains up-to-date with the latest stable releases.